### PR TITLE
Trigger frame event on NMI, with trigger on vcounter() == 241 as fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ gba := gba
 profile := accuracy
 target  := libretro
 
+# SFC input lag fix
+sfc_lagfix := 1
+
 # options += debugger
 # arch := x86
 # console := true

--- a/sfc/Makefile
+++ b/sfc/Makefile
@@ -32,6 +32,10 @@ else
   $(error unknown profile.)
 endif
 
+ifeq ($(sfc_lagfix),1)
+	flags += -DSFC_LAGFIX
+endif
+
 obj/sfc-interface-$(profile).o:       $(sfc)/interface/interface.cpp $(call rwildcard,$(sfc)/interface)
 obj/sfc-system-$(profile).o:          $(sfc)/system/system.cpp $(call rwildcard,$(sfc)/system/)
 obj/sfc-controller-$(profile).o:      $(sfc)/controller/controller.cpp $(call rwildcard,$(sfc)/controller/)

--- a/sfc/alt/cpu/cpu.cpp
+++ b/sfc/alt/cpu/cpu.cpp
@@ -138,6 +138,10 @@ void CPU::reset() {
   status.nmi_line = false;
   status.nmi_transition = false;
   status.nmi_pending = false;
+  
+#ifdef SFC_LAGFIX
+  status.frame_event_performed = false;
+#endif
 
   status.irq_valid = false;
   status.irq_line = false;

--- a/sfc/alt/cpu/cpu.hpp
+++ b/sfc/alt/cpu/cpu.hpp
@@ -106,6 +106,10 @@ private:
     bool nmi_line;
     bool nmi_transition;
     bool nmi_pending;
+    
+#ifdef SFC_LAGFIX
+    bool frame_event_performed;
+#endif
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/alt/cpu/serialization.cpp
+++ b/sfc/alt/cpu/serialization.cpp
@@ -40,6 +40,10 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_line);
   s.integer(status.nmi_transition);
   s.integer(status.nmi_pending);
+  
+#ifdef SFC_LAGFIX
+  s.integer(status.frame_event_performed);
+#endif
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/cpu/cpu.hpp
+++ b/sfc/cpu/cpu.hpp
@@ -56,6 +56,10 @@ privileged:
     bool nmi_transition;
     bool nmi_pending;
     bool nmi_hold;
+    
+#ifdef SFC_LAGFIX
+    bool frame_event_performed;
+#endif
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/cpu/serialization.cpp
+++ b/sfc/cpu/serialization.cpp
@@ -30,6 +30,10 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_transition);
   s.integer(status.nmi_pending);
   s.integer(status.nmi_hold);
+  
+#ifdef SFC_LAGFIX
+  s.integer(status.frame_event_performed);
+#endif
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/cpu/timing/irq.cpp
+++ b/sfc/cpu/timing/irq.cpp
@@ -9,7 +9,14 @@ void CPU::poll_interrupts() {
   //NMI hold
   if(status.nmi_hold) {
     status.nmi_hold = false;
-    if(status.nmi_enabled) status.nmi_transition = true;
+    if(status.nmi_enabled)
+    {
+      status.nmi_transition = true;
+#ifdef SFC_LAGFIX
+      scheduler.exit(Scheduler::ExitReason::FrameEvent);
+      status.frame_event_performed = true;
+#endif
+    }
   }
 
   //NMI test
@@ -57,6 +64,10 @@ void CPU::nmitimen_update(uint8 data) {
   //0->1 edge sensitive transition
   if(!nmi_enabled && status.nmi_enabled && status.nmi_line) {
     status.nmi_transition = true;
+#ifdef SFC_LAGFIX
+    scheduler.exit(Scheduler::ExitReason::FrameEvent);
+    status.frame_event_performed = true;
+#endif
   }
 
   //?->1 level sensitive transition

--- a/sfc/cpu/timing/timing.cpp
+++ b/sfc/cpu/timing/timing.cpp
@@ -44,9 +44,17 @@ void CPU::scanline() {
   synchronize_smp();
   synchronize_ppu();
   synchronize_coprocessors();
+#ifdef SFC_LAGFIX
+  system.scanline(status.frame_event_performed);
+#else
   system.scanline();
+#endif
 
   if(vcounter() == 0) {
+#ifdef SFC_LAGFIX
+    status.frame_event_performed = false;
+#endif
+    
     //HDMA init triggers once every frame
     status.hdma_init_position = (cpu_version == 1 ? 12 + 8 - dma_counter() : 12 + dma_counter());
     status.hdma_init_triggered = false;
@@ -179,6 +187,10 @@ void CPU::timing_reset() {
   status.nmi_transition = false;
   status.nmi_pending    = false;
   status.nmi_hold       = false;
+  
+#ifdef SFC_LAGFIX
+  status.frame_event_performed = false;
+#endif
 
   status.irq_valid      = false;
   status.irq_line       = false;

--- a/sfc/system/system.cpp
+++ b/sfc/system/system.cpp
@@ -241,8 +241,17 @@ void System::reset() {
 }
 
 void System::scanline() {
+  bool frame_event_performed = false;
+  scanline(frame_event_performed);
+}
+
+void System::scanline(bool& frame_event_performed) {
   video.scanline();
-  if(cpu.vcounter() == 241) scheduler.exit(Scheduler::ExitReason::FrameEvent);
+  if(cpu.vcounter() == 241 && !frame_event_performed)
+  {
+    scheduler.exit(Scheduler::ExitReason::FrameEvent);
+    frame_event_performed = true;
+  }
 }
 
 void System::frame() {

--- a/sfc/system/system.hpp
+++ b/sfc/system/system.hpp
@@ -15,6 +15,7 @@ struct System : property<System> {
   void reset();
 
   void frame();
+  void scanline(bool& frame_event_performed);
   void scanline();
 
   //return *active* system information (settings are cached upon power-on)


### PR DESCRIPTION
This is a fix that removes one full frame of input lag. This fix is identical to the one made for bsnes-mercury; see pull request with details here:

https://github.com/libretro/bsnes-mercury/pull/18

This pull request includes the changes proposed by Alcaro here: https://github.com/libretro/bsnes-mercury/pull/18#issuecomment-229416570

The implementation has been successfully tested in the same way as the bsnes-mercury one, i.e.:
- Confirm input lag improvement for all three profiles (accuracy, balanced, performance).
- Confirm that defining SFC_LAGFIX=0 results in original behavior for all three profiles.
- Analyze behavior of the last scanline with no overscan and overscan.
