### PR TITLE
Revert 'Better error handling'

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -803,9 +803,6 @@ static void init_descriptors(void)
 
 bool retro_load_game(const struct retro_game_info *info)
 {
-   if (!info)
-      return false;
-
   // Support loading a manifest directly.
   core_bind.manifest = info->path && string(info->path).endsWith(".bml");
   init_descriptors();


### PR DESCRIPTION
Reverts https://github.com/libretro/bsnes-libretro/commit/4c99c5a1ee3b1389a04d97e5e880c33466ebe5fb.

See https://github.com/libretro/RetroArch/issues/4493.