### PR TITLE
Silence -Wparentheses warnings

### DIFF
--- a/nall/atoi.hpp
+++ b/nall/atoi.hpp
@@ -7,7 +7,7 @@ namespace nall {
 
 constexpr inline uintmax_t binary_(const char* s, uintmax_t sum = 0) {
   return (
-    *s == '0' || *s == '1' ? binary_(s + 1, (sum << 1) | *s - '0') :
+    *s == '0' || *s == '1' ? binary_(s + 1, (sum << 1) | (*s - '0')) :
     *s == '\'' ? binary_(s + 1, sum) :
     sum
   );
@@ -15,7 +15,7 @@ constexpr inline uintmax_t binary_(const char* s, uintmax_t sum = 0) {
 
 constexpr inline uintmax_t octal_(const char* s, uintmax_t sum = 0) {
   return (
-    *s >= '0' && *s <= '7' ? octal_(s + 1, (sum << 3) | *s - '0') :
+    *s >= '0' && *s <= '7' ? octal_(s + 1, (sum << 3) | (*s - '0')) :
     *s == '\'' ? octal_(s + 1, sum) :
     sum
   );
@@ -31,9 +31,9 @@ constexpr inline uintmax_t decimal_(const char* s, uintmax_t sum = 0) {
 
 constexpr inline uintmax_t hex_(const char* s, uintmax_t sum = 0) {
   return (
-    *s >= 'A' && *s <= 'F' ? hex_(s + 1, (sum << 4) | *s - 'A' + 10) :
-    *s >= 'a' && *s <= 'f' ? hex_(s + 1, (sum << 4) | *s - 'a' + 10) :
-    *s >= '0' && *s <= '9' ? hex_(s + 1, (sum << 4) | *s - '0') :
+    *s >= 'A' && *s <= 'F' ? hex_(s + 1, (sum << 4) | (*s - 'A' + 10)) :
+    *s >= 'a' && *s <= 'f' ? hex_(s + 1, (sum << 4) | (*s - 'a' + 10)) :
+    *s >= '0' && *s <= '9' ? hex_(s + 1, (sum << 4) | (*s - '0')) :
     *s == '\'' ? hex_(s + 1, sum) :
     sum
   );


### PR DESCRIPTION
If compiled with `-Wall` this will silence the following `-Wparentheses` warnings.
```
./nall/atoi.hpp: In function ‘constexpr uintmax_t nall::binary_(const char*, uintmax_t)’:
./nall/atoi.hpp:10:61: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     *s == '0' || *s == '1' ? binary_(s + 1, (sum << 1) | *s - '0') :
                                                             ^
./nall/atoi.hpp: In function ‘constexpr uintmax_t nall::octal_(const char*, uintmax_t)’:
./nall/atoi.hpp:18:60: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     *s >= '0' && *s <= '7' ? octal_(s + 1, (sum << 3) | *s - '0') :
                                                            ^
./nall/atoi.hpp: In function ‘constexpr uintmax_t nall::hex_(const char*, uintmax_t)’:
./nall/atoi.hpp:34:64: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     *s >= 'A' && *s <= 'F' ? hex_(s + 1, (sum << 4) | *s - 'A' + 10) :
                                                                ^
./nall/atoi.hpp:35:64: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     *s >= 'a' && *s <= 'f' ? hex_(s + 1, (sum << 4) | *s - 'a' + 10) :
                                                                ^
./nall/atoi.hpp:36:58: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
     *s >= '0' && *s <= '9' ? hex_(s + 1, (sum << 4) | *s - '0') :
                                                          ^
```