### PR TITLE
Cleanup endian.h include

### DIFF
--- a/nall/platform.hpp
+++ b/nall/platform.hpp
@@ -41,9 +41,7 @@ namespace Math {
   #undef interface
   #define dllexport __declspec(dllexport)
 #else
-  #ifdef __APPLE__
-    #include <machine/endian.h>
-  #elif __linux__
+  #ifdef __linux__
     #include <endian.h>
   #else
     #include <machine/endian.h>


### PR DESCRIPTION
Very minor cleanup. This turns this `#ifdef` around to avoid repetition.

Also see https://github.com/libretro/bsnes-libretro/pull/21.