### PR TITLE
Silence a -Wreturn-type warning

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -368,6 +368,7 @@ struct Callbacks : Emulator::Interface::Bind {
     if (video_fmt == video_fmt_32) return (r << 16) | (g << 8) | (b << 0);
     if (video_fmt == video_fmt_16) return (r>>3 << 11) | (g>>2 << 5) | (b>>3 << 0);
     if (video_fmt == video_fmt_15) return (r>>3 << 10) | (g>>3 << 5) | (b>>3 << 0);
+    return 0;
   }
 };
 


### PR DESCRIPTION
Silences a `-Wreturn-type` warning with clang.
```
target-libretro/libretro.cpp:371:3: warning: control may reach end of non-void
      function [-Wreturn-type]
  }
  ^
```
Same fix as https://github.com/libretro/bsnes-mercury/pull/41