### PR TITLE
Add cheats to SNES games

### DIFF
--- a/gb/cheat/cheat.cpp
+++ b/gb/cheat/cheat.cpp
@@ -1,4 +1,5 @@
 #include <gb/gb.hpp>
+#include <iostream>
 
 namespace GameBoy {
 
@@ -23,6 +24,16 @@ optional<unsigned> Cheat::find(unsigned addr, unsigned comp) {
     }
   }
   return false;
+}
+
+bool Cheat::decode(const char *part, unsigned &addr, unsigned &comp, unsigned &data) {
+  std::cerr << "[bsnes]: Decoding cheats not implemented." << std::endl;
+  return false;
+}
+
+void Cheat::synchronize() {
+  std::cerr << "[bsnes]: Synchronizing cheats not implemented." << std::endl;
+  return;
 }
 
 }

--- a/gb/cheat/cheat.cpp
+++ b/gb/cheat/cheat.cpp
@@ -27,6 +27,14 @@ optional<unsigned> Cheat::find(unsigned addr, unsigned comp) {
 }
 
 bool Cheat::decode(const char *part, unsigned &addr, unsigned &comp, unsigned &data) {
+  /* Code Types
+   * RAW:
+   *   AAAA:DD
+   * Game Genie: http://gamehacking.org/library/114
+   * GameShark: 0BDDAAAA - Byteswapped Address, bank+1
+   * Codebreaker: 0BAAAA-DD
+   * Xploder: Unknown
+   */
   std::cerr << "[bsnes]: Decoding cheats not implemented." << std::endl;
   return false;
 }

--- a/gb/cheat/cheat.hpp
+++ b/gb/cheat/cheat.hpp
@@ -12,6 +12,9 @@ struct Cheat {
   void append(unsigned addr, unsigned data);
   void append(unsigned addr, unsigned comp, unsigned data);
   optional<unsigned> find(unsigned addr, unsigned comp);
+  
+  bool decode(const char *part, unsigned &addr, unsigned &comp, unsigned &data);
+  void synchronize();
 };
 
 extern Cheat cheat;

--- a/sfc/cheat/cheat.cpp
+++ b/sfc/cheat/cheat.cpp
@@ -1,4 +1,5 @@
 #include <sfc/sfc.hpp>
+#include <iostream>
 
 #define CHEAT_CPP
 namespace SuperFamicom {
@@ -27,6 +28,16 @@ optional<unsigned> Cheat::find(unsigned addr, unsigned comp) {
     }
   }
   return false;
+}
+
+bool Cheat::decode(const char *part, unsigned &addr, unsigned &data) {
+  std::cerr << "[bsnes]: Decoding cheats not implemented." << std::endl;
+  return false;
+}
+
+void Cheat::synchronize() {
+  std::cerr << "[bsnes]: Synchronizing cheats not implemented." << std::endl;
+  return;
 }
 
 }

--- a/sfc/cheat/cheat.cpp
+++ b/sfc/cheat/cheat.cpp
@@ -1,5 +1,6 @@
 #include <sfc/sfc.hpp>
 #include <iostream>
+#include <cstdlib>
 
 #define CHEAT_CPP
 namespace SuperFamicom {
@@ -30,13 +31,145 @@ optional<unsigned> Cheat::find(unsigned addr, unsigned comp) {
   return false;
 }
 
+static char genie_replace(char input){
+  switch (input){
+    case '0':
+      return '4';
+    case '1':
+      return '6';
+    case '2':
+      return 'D';
+    case '3':
+      return 'E';
+    case '4':
+      return '2';
+    case '5':
+      return '7';
+    case '6':
+      return '8';
+    case '7':
+      return '3';
+    case '8':
+      return 'B';
+    case '9':
+      return '5';
+    case 'A':
+    case 'a':
+      return 'C';
+    case 'B':
+    case 'b':
+      return '9';
+    case 'C':
+    case 'c':
+      return 'A';
+    case 'D':
+    case 'd':
+      return '0';
+    case 'E':
+    case 'e':
+      return 'F';
+    case 'F':
+    case 'f':
+      return '1';
+  }
+}
+
 bool Cheat::decode(const char *part, unsigned &addr, unsigned &data) {
-  std::cerr << "[bsnes]: Decoding cheats not implemented." << std::endl;
-  return false;
+  char addr_str[7], data_str[3];
+  addr_str[6]=0;
+  data_str[2]=0;
+  addr=data=0;
+
+  //RAW
+  if (strlen(part)>=9 && part[6]==':') {
+    strncpy(addr_str,part,6);
+    strncpy(data_str,part+7,2);
+    addr=strtoul(addr_str,'\0',16);
+    data=strtoul(data_str,'\0',16);
+  }
+
+  //Game Genie
+  else if (strlen(part)>=9 && part[4]=='-') {
+    strncpy(data_str,part,2);
+    strncpy(addr_str,part+2,2);
+    strncpy(addr_str+2,part+5,4);
+    for (int i=0;i<2;i++)
+      data_str[i]=genie_replace(data_str[i]);
+    for (int i=0;i<6;i++)
+      addr_str[i]=genie_replace(addr_str[i]);
+    data=strtoul(data_str,'\0',16);
+    int addr_scrambled=strtoul(addr_str,'\0',16);
+    addr=(addr_scrambled&0x003C00)<<10;
+    addr|=(addr_scrambled&0x00003C)<<14;
+    addr|=(addr_scrambled&0xF00000)>>8;
+    addr|=(addr_scrambled&0x000003)<<10;
+    addr|=(addr_scrambled&0x00C000)>>6;
+    addr|=(addr_scrambled&0x0F0000)>>12;
+    addr|=(addr_scrambled&0x0003C0)>>6;
+    return true;
+  }
+
+  //PAR & X-Terminator
+  else if (strlen(part)==8) {
+    strncpy(addr_str,part,6);
+    strncpy(data_str,part+6,2);
+    addr=strtoul(addr_str,'\0',16);
+    data=strtoul(data_str,'\0',16);
+  }
+
+  //Gold Finger
+  else if (strlen(part)==14) {
+    if (part[13]=='1'){
+      std::cout << "[bsnes]: CHEAT: Goldfinger SRAM cheats not supported: " << part << std::endl;
+      return false;
+    }
+    addr_str[0]='0';
+    strncpy(addr_str+1,part,5);
+    strncpy(data_str,part+5,2);
+    if (part[7]!='X' && part[7]!='x')
+      std::cout << "[bsnes]: CHEAT: Goldfinger multibyte cheats not supported: " << part << std::endl;
+
+    char pair_str[3];
+    pair_str[2]=0;
+    int csum_calc=0,csum_code;
+    for (int i=0;i<6;i++){
+      if (i<3){
+        strncpy(pair_str,addr_str+2*i,2);
+      } else {
+        strncpy(pair_str,part+2*i-1,2);
+      }
+      csum_calc+=strtoul(pair_str,'\0',16);
+    }
+    csum_calc-=0x160;
+    csum_calc&=0xFF;
+    strncpy(pair_str,part+11,2);
+    csum_code=strtoul(pair_str,'\0',16);
+    if (csum_calc!=csum_code){
+      std::cout << "[bsnes]: CHEAT: Goldfinger calculated checksum '" << std::hex << csum_calc <<  "' doesn't match code: " << part << std::endl;
+      return false;
+    }
+
+    int addr_scrambled=strtoul(addr_str,'\0',16);
+    addr=(addr_scrambled&0x7FFF)|((addr_scrambled&0x7F8000)<<1)|0x8000;
+    data=strtoul(data_str,'\0',16);
+    std::cout << "CHEAT: " << part << " decoded as " << std::hex <<  addr << ":" << data << std::endl;
+  }
+
+  //Unknown
+  else {
+    std::cout << "[bsnes]: CHEAT: Unrecognized code type: " << part << std::endl;
+    return false;
+  }
+
+  if (addr == 0 || data == 0){
+    std::cout << "[bsnes]: CHEAT: Decoding failed: " << part << std::endl;
+    return false;
+  }
+
+  return true;
 }
 
 void Cheat::synchronize() {
-  std::cerr << "[bsnes]: Synchronizing cheats not implemented." << std::endl;
   return;
 }
 

--- a/sfc/cheat/cheat.hpp
+++ b/sfc/cheat/cheat.hpp
@@ -12,6 +12,9 @@ struct Cheat {
   void append(unsigned addr, unsigned data);
   void append(unsigned addr, unsigned comp, unsigned data);
   optional<unsigned> find(unsigned addr, unsigned comp);
+  
+  bool decode(const char *part, unsigned &addr, unsigned &data);
+  void synchronize();
 };
 
 extern Cheat cheat;

--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -400,8 +400,7 @@ Interface::Interface() {
   core_bind.iface = &core_interface;
 }
 
-void Interface::setCheats(const lstring &) {
-#if 0
+void Interface::setCheats(const lstring & list) {
   if(core_interface.mode == SuperFamicomCartridge::ModeSuperGameBoy) {
     GameBoy::cheat.reset();
     for(auto &code : list) {
@@ -409,8 +408,8 @@ void Interface::setCheats(const lstring &) {
       codelist.split("+", code);
       for(auto &part : codelist) {
         unsigned addr, data, comp;
-        if(GameBoy::Cheat::decode(part, addr, data, comp)) {
-          GameBoy::cheat.append({addr, data, comp});
+        if(GameBoy::cheat.decode(part, addr, comp, data)) {
+          GameBoy::cheat.append(addr, comp, data);
         }
       }
     }
@@ -424,14 +423,13 @@ void Interface::setCheats(const lstring &) {
     codelist.split("+", code);
     for(auto &part : codelist) {
       unsigned addr, data;
-      if(SuperFamicom::Cheat::decode(part, addr, data)) {
-        SuperFamicom::cheat.append({addr, data});
+      if(SuperFamicom::cheat.decode(part, addr, data)) {
+        SuperFamicom::cheat.append(addr, data);
       }
     }
   }
 
   SuperFamicom::cheat.synchronize();
-#endif
 }
 
 unsigned retro_api_version(void) {
@@ -583,7 +581,7 @@ void retro_cheat_reset(void) {
 }
 
 void retro_cheat_set(unsigned index, bool enable, const char *code) {
-  cheatList.reserve(index+1);
+  cheatList.resize(index+1);
   cheatList[index].enable = enable;
   cheatList[index].code = code;
 


### PR DESCRIPTION
First things first, don't ask me how this works because I have no idea.  All I did was add decoding functions to the cheat class, and next thing I know the cheats are already fully active.

Cheat Formats Supported:

* RAW - 012345:AB
* Game Genie - 0123-ABCD
* PAR - 012345AB
* Gold Finger - 12345ABXXXXC60

Known Issues:

* ROM cheats can't be turned off, save for by reopening the game and not loading any savestates from when the cheats were turned on.  I can't for the life of me figure out how or why the cheats are even being run, so I can't fix it.
* Multi-byte Gold Finger cheats not implemented.  I'd have to move the decoding to outside the cheats class to have a shot at it and I'm not ready to refactor the code to that extent.  These cheats throw warnings to stdout.  Ideally a warning would print to the onscreen text, but I'm too lazy to look up the retroarch API and figure out how to do that at this time.
* SGB cheats not implemented yet.  Related to that, I'm currently looking for documentation on the Xploder for GameBoy cheat format, and have come up empty on it.

This will be ported to bsnes-mercury and bsnes-c++98 after all resolvable known issues are resolved.
