### PR TITLE
travis: Build all three core profiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ env:
     - CORE=bsnes
     - COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7 CXX11=g++-7
   matrix:
-    - PLATFORM=linux_x64
+    - PLATFORM=linux_x64 NAME=bsnes_accuracy
+    - PLATFORM=linux_x64 NAME=bsnes_balanced
+    - PLATFORM=linux_x64 NAME=bsnes_performance
 before_script:
   - pwd
   - mkdir -p ~/bin


### PR DESCRIPTION
Tests all three core profiles with travis, only merge this if travis builds correctly.

Also see https://github.com/libretro/bsnes-mercury/pull/61.