### PR TITLE
Change library_name to bsnes2014

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -186,7 +186,7 @@ struct Callbacks : Emulator::Interface::Bind {
 
   void saveRequest(unsigned id, string p) {
     if (manifest) {
-      fprintf(stderr, "[bsnes]: [Save]: ID %u, Request \"%s\".\n", id, (const char*)p);
+      fprintf(stderr, "[bsnes2014]: [Save]: ID %u, Request \"%s\".\n", id, (const char*)p);
       string save_path = {path(0), p};
       filestream stream(save_path, file::mode::write);
       iface->save(id, stream);
@@ -208,11 +208,11 @@ struct Callbacks : Emulator::Interface::Bind {
         mmapstream stream(load_path);
         iface->load(id, stream);
       } else {
-        fprintf(stderr, "[bsnes]: Cannot find requested file in system directory: \"%s\".\n", (const char*)load_path);
+        fprintf(stderr, "[bsnes2014]: Cannot find requested file in system directory: \"%s\".\n", (const char*)load_path);
         load_request_error = true;
       }
     } else {
-      fprintf(stderr, "[bsnes]: Cannot find requested file: \"%s\" in ROM directory nor system directory.\n", (const char*)p);
+      fprintf(stderr, "[bsnes2014]: Cannot find requested file: \"%s\" in ROM directory nor system directory.\n", (const char*)p);
       load_request_error = true;
     }
   }
@@ -243,7 +243,7 @@ struct Callbacks : Emulator::Interface::Bind {
   }
 
   void loadRequestManifest(unsigned id, const string& p) {
-    fprintf(stderr, "[bsnes]: [Manifest]: ID %u, Request \"%s\".\n", id, (const char*)p);
+    fprintf(stderr, "[bsnes2014]: [Manifest]: ID %u, Request \"%s\".\n", id, (const char*)p);
     switch(id) {
       case SuperFamicom::ID::IPLROM:
         loadIPLROM(id);
@@ -260,7 +260,7 @@ struct Callbacks : Emulator::Interface::Bind {
   }
 
   void loadRequestMemory(unsigned id, const string& p) {
-    fprintf(stderr, "[bsnes]: [Memory]: ID %u, Request \"%s\".\n", id, (const char*)p);
+    fprintf(stderr, "[bsnes2014]: [Memory]: ID %u, Request \"%s\".\n", id, (const char*)p);
     switch(id) {
       case SuperFamicom::ID::Manifest:
         loadManifest(id);
@@ -276,7 +276,7 @@ struct Callbacks : Emulator::Interface::Bind {
       case SuperFamicom::ID::SDD1ROM:
       case SuperFamicom::ID::HitachiDSPROM:
       case SuperFamicom::ID::SPC7110PROM:
-        fprintf(stderr, "[bsnes]: Load ROM.\n");
+        fprintf(stderr, "[bsnes2014]: Load ROM.\n");
         loadROM(id);
         break;
 
@@ -331,7 +331,7 @@ struct Callbacks : Emulator::Interface::Bind {
         break;
 
       default:
-        fprintf(stderr, "[bsnes]: Load BIOS.\n");
+        fprintf(stderr, "[bsnes2014]: Load BIOS.\n");
         loadFile(id, p);
         break;
     }
@@ -342,18 +342,18 @@ struct Callbacks : Emulator::Interface::Bind {
        loadRequestManifest(id, p);
     else
        loadRequestMemory(id, p);
-    fprintf(stderr, "[bsnes]: Complete load request.\n");
+    fprintf(stderr, "[bsnes2014]: Complete load request.\n");
   }
 
   void loadRequest(unsigned id, string p, string manifest) {
     switch (id) {
       case SuperFamicom::ID::SuperGameBoy:
-        fprintf(stderr, "[bsnes]: Loading GB ROM.\n");
+        fprintf(stderr, "[bsnes2014]: Loading GB ROM.\n");
         loadSGBROMManifest(id);
         break;
 
       default:
-        fprintf(stderr, "[bsnes]: Didn't do anything with loadRequest (3 arg).\n");
+        fprintf(stderr, "[bsnes2014]: Didn't do anything with loadRequest (3 arg).\n");
     }
   }
 
@@ -705,7 +705,7 @@ void retro_get_system_info(struct retro_system_info *info) {
 #define GIT_VERSION ""
 #endif
   static string version("v", Emulator::Version, " (", Emulator::Profile, ")", GIT_VERSION);
-  info->library_name     = "bsnes";
+  info->library_name     = "bsnes2014";
   info->library_version  = version;
   info->valid_extensions = "sfc|smc|bml";
   info->need_fullpath    = false;
@@ -751,7 +751,7 @@ static bool snes_load_cartridge_normal(
   core_bind.rom_data = rom_data;
   core_bind.rom_size = rom_size;
   core_bind.xmlrom   = xmlrom;
-  fprintf(stderr, "[bsnes]: XML map:\n%s\n", (const char*)xmlrom);
+  fprintf(stderr, "[bsnes2014]: XML map:\n%s\n", (const char*)xmlrom);
   core_bind.iface->load(SuperFamicom::ID::SuperFamicom);
   SuperFamicom::system.power();
   return !core_bind.load_request_error;
@@ -817,8 +817,8 @@ static bool snes_load_cartridge_super_game_boy(
 ) {
   string xmlrom_sgb = (rom_xml && *rom_xml) ? string(rom_xml) : SuperFamicomCartridge(rom_data, rom_size).markup;
   string xmlrom_gb  = (dmg_xml && *dmg_xml) ? string(dmg_xml) : GameBoyCartridge((uint8_t*)dmg_data, dmg_size).markup;
-  fprintf(stderr, "[bsnes]: Markup SGB: %s\n", (const char*)xmlrom_sgb);
-  fprintf(stderr, "[bsnes]: Markup GB: %s\n", (const char*)xmlrom_gb);
+  fprintf(stderr, "[bsnes2014]: Markup SGB: %s\n", (const char*)xmlrom_sgb);
+  fprintf(stderr, "[bsnes2014]: Markup GB: %s\n", (const char*)xmlrom_gb);
 
   core_bind.rom_data    = rom_data;
   core_bind.rom_size    = rom_size;


### PR DESCRIPTION
This should avoid folder name collisions with the new BSNES core when using "Sort Saves in Folders/Sort SaveStates in Folders"

Reference: https://github.com/libretro/RetroArch/issues/9537