### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T
-   CC = gcc
+   CC ?= gcc
    IS_X86 = 0
 ifneq (,$(findstring cortexa8,$(platform)))
    FLAGS += -marm -mcpu=cortex-a8
@@ -292,7 +292,8 @@ ifneq (,$(findstring softfloat,$(platform)))
 else ifneq (,$(findstring hardfloat,$(platform)))
    FLAGS += -mfloat-abi=hard
 endif
-   FLAGS += -DARM
+   arch = arm
+   LDFLAGS += -ldl
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but actual compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).
Added missing lib and removed -DARM which actually breaks compilation. CC definition changed to optional to allow cross-compilation.