### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -90,6 +94,12 @@ stages:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit
@@ -173,6 +183,12 @@ libretro-build-linux-x64-balanced:
     - .libretro-linux-x64-make-default
     - .core-defs-balanced
 
+# Linux ARM 64-bit
+libretro-build-linux-aarch64-balanced:
+  extends:
+    - .libretro-linux-aarch64-make-default
+    - .core-defs-balanced
+
 # Linux 32-bit
 libretro-build-linux-i686-balanced:
   extends:
@@ -252,6 +268,12 @@ libretro-build-tvos-arm64-balanced:
 libretro-build-linux-x64-accuracy:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs-accuracy
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64-accuracy:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs-accuracy
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux builds of bsnes2014, so none of the three profiles can be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: there is no x86 assembly and no x86-specific flag anywhere in the Makefile, and `android-arm64-v8a` and `osx-arm64` already build these sources for ARM64 for all three profiles.

Three jobs, mirroring the existing `libretro-build-linux-x64*` ones and keeping each profile's own `.core-defs*`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

(plus `-balanced` and `-accuracy`), and the matching `/linux-aarch64.yml` template include. The file uses CRLF line endings; the patch keeps them.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc, GCC 15): `make platform=unix PROFILE=performance` builds clean with no source changes, producing `bsnes2014_performance_libretro.so` (ELF 64-bit ARM aarch64). Running a SNES test ROM in a minimal libretro host it emulates 300 frames at 256x224 / 60.10 fps with correct audio pacing (533 frames per `retro_run` at 32040 Hz) and plenty of headroom - about 650% of realtime.
